### PR TITLE
Add cat picture command

### DIFF
--- a/src/main/java/de/yjulian/merly/subsystem/command/CommandManagerImpl.java
+++ b/src/main/java/de/yjulian/merly/subsystem/command/CommandManagerImpl.java
@@ -6,6 +6,7 @@ import de.yjulian.merly.util.*;
 import de.yjulian.merly.bot.MerlyBot;
 import de.yjulian.merly.exceptions.CommandException;
 import de.yjulian.merly.subsystem.command.initial.HelpProviderCommand;
+import de.yjulian.merly.subsystem.command.initial.CatPictureCommand;
 import net.dv8tion.jda.api.entities.*;
 import org.jetbrains.annotations.Nullable;
 
@@ -77,6 +78,7 @@ public class CommandManagerImpl implements CommandManager, AliasManager, EventAd
 
     private void registerDefault() {
         addCommand(new HelpProviderCommand());
+        addCommand(new CatPictureCommand());
     }
 
     public AliasCommand applyAlias(String prefix) {

--- a/src/main/java/de/yjulian/merly/subsystem/command/initial/CatPictureCommand.java
+++ b/src/main/java/de/yjulian/merly/subsystem/command/initial/CatPictureCommand.java
@@ -1,0 +1,36 @@
+package de.yjulian.merly.subsystem.command.initial;
+
+import de.yjulian.merly.subsystem.command.CommandArguments;
+import de.yjulian.merly.subsystem.command.GenericCommand;
+import de.yjulian.merly.subsystem.command.Help;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+
+/**
+ * Command that sends a random cat picture to the invoking channel.
+ */
+public class CatPictureCommand implements GenericCommand {
+
+    private static final String API_URL = "https://cataas.com/cat";
+
+    @Override
+    public String prefix() {
+        return "cat";
+    }
+
+    @Override
+    public void onExecute(CommandArguments arguments) {
+        try (InputStream is = new URL(API_URL).openStream()) {
+            arguments.getMessageChannel().sendFile(is, "cat.jpg").queue();
+        } catch (IOException e) {
+            arguments.getMessageChannel().sendMessage("Could not load cat image.").queue();
+        }
+    }
+
+    @Override
+    public Help helpProvider() {
+        return Help.Builder("Sends a random cat picture.").build();
+    }
+}


### PR DESCRIPTION
## Summary
- add `CatPictureCommand` to fetch random cat images
- register the new command in `CommandManagerImpl`

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f4e78ab84832fa73bb656941cb175